### PR TITLE
Fix infinite loop on malformed input

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -43,3 +43,7 @@ class ParseTestCase(unittest.TestCase):
                     self.assertEqual(left[1][0], right)
                     self.assertEqual(left[1][1], parsed[right])
 
+    def testMalformed(self):
+        rv = www_authenticate.parse("malformed: out")
+
+        self.assertEqual({"malformed": None}, dict(rv.items()))

--- a/www_authenticate.py
+++ b/www_authenticate.py
@@ -62,13 +62,19 @@ def _group_challenges(tokens):
 def parse(value):
     tokens = []
     while value:
+        has_match = False
         for token_name, pattern in _tokens:
             match = pattern.match(value)
             if match:
+                has_match = True
                 value = value[match.end():]
                 if token_name:
                     tokens.append((token_name, match.group(1)))
                 break
+
+        if not has_match:
+            break
+
     _group_pairs(tokens)
 
     challenges = CaseFoldedOrderedDict()


### PR DESCRIPTION
When no pattern matches the remaining string, the loop goes on and attempts matching the same patterns again. This fix introduces an exit condition to avoid the problem, preventing infinite loops from forged headers.
